### PR TITLE
Update to Nette 2.0b

### DIFF
--- a/DependentSelectBox.php
+++ b/DependentSelectBox.php
@@ -7,7 +7,7 @@
 
 namespace DependentSelectBox;
 
-use Nette\Forms\SelectBox;
+use Nette\Forms\Controls\SelectBox;
 use InvalidArgumentException;
 use LogicException;
 use NotSupportedException;
@@ -72,7 +72,7 @@ class DependentSelectBox extends SelectBox {
 
 			if($parent instanceof DependentSelectBox)
 				$parent->childs[] = $this;
-			if(!self::$disableChilds && $this->isRoot($parent) && $parent instanceof SelectBox && $parent->isFirstSkipped())
+			if(!self::$disableChilds && $this->isRoot($parent) && $parent instanceof SelectBox && $parent->getPrompt())
 				throw new NotSupportedException('When first item on root is skipped, $disableChilds = false cant be used !');
 		}
 	}
@@ -225,7 +225,7 @@ class DependentSelectBox extends SelectBox {
 	 * @param boolean $recursive Refresh all items in tree or only this item ?
 	 */
 	public function refresh($clearValue = false, $recursive = true) {
-		$this->skipFirst(false);
+		$this->setPrompt(false);
 		if($clearValue)
 			$this->setValue(null, false);
 		$this->initializeState($this->getForm());
@@ -342,7 +342,7 @@ class DependentSelectBox extends SelectBox {
 		if($this->disabledValue === null) {
 			$this->setValue(null, false);
 			$this->setItems(array());
-			$this->skipFirst(self::$disabledItemTitle);
+			$this->setPrompt(self::$disabledItemTitle);
 		} else {
 			$keys = array_keys($this->disabledValue);
 			$key = reset($keys);
@@ -372,7 +372,7 @@ class DependentSelectBox extends SelectBox {
 	 * Add empty header item and select him
 	 */
 	protected function addEmptyHeaderItem($selectFirst = true) {
-		$this->skipFirst(self::$emptyValueTitle);
+		$this->setPrompt(self::$emptyValueTitle);
 		if($selectFirst)
 			$this->setFirstItemSelected();
 	}

--- a/FormControlDependencyHelper.php
+++ b/FormControlDependencyHelper.php
@@ -7,9 +7,9 @@
 
 namespace DependentSelectBox;
 
-use Nette\Forms\FormContainer;
-use Nette\Forms\FormControl;
-use Nette\Forms\SubmitButton;
+use Nette\Forms\Container;
+use Nette\Forms\Controls\BaseControl as FormControl;
+use Nette\Forms\Controls\SubmitButton;
 use Nette\Object;
 use \InvalidArgumentException;
 use \InvalidStateException;
@@ -56,7 +56,7 @@ class FormControlDependencyHelper extends Object {
 		$this->control = $control;
 		$this->controlClass = $controlClass;
 		$this->buttonPosition = self::$defaultButtonPosition;
-		if($this->control->lookup("Nette\Forms\FormContainer", false) === null)
+		if($this->control->lookup("Nette\Forms\Container", false) === null)
 			throw new InvalidArgumentException("Components should be assigned to FormContainer !");
 	}
 
@@ -69,7 +69,7 @@ class FormControlDependencyHelper extends Object {
 	 * @return boolean
 	 */
 	public function isAnyButtonAttached() {
-		$form = $this->control->lookup("Nette\Forms\FormContainer");
+		$form = $this->control->lookup("Nette\Forms\Container");
 		$buttonName = $this->formatButtonName($this->control->getName());
 		$button = $form->getComponent($buttonName, false);
 		return $button !== null;
@@ -81,7 +81,7 @@ class FormControlDependencyHelper extends Object {
 	 * @return SubmitButton
 	 */
 	public function getAnyAttachedButton($need = false) {
-		$form = $this->control->lookup("Nette\Forms\FormContainer");
+		$form = $this->control->lookup("Nette\Forms\Container");
 		$buttonName = $this->formatButtonName($this->control->getName());
 		$button = $form->getComponent($buttonName, $need);
 		return $button;
@@ -152,7 +152,7 @@ class FormControlDependencyHelper extends Object {
 		// create button
 		if($this->buttonText === null)
 			throw new InvalidArgumentException("Null caption of button is crappy *** !!! (ajax not working properly)");
-		$container = $this->control->lookup("Nette\Forms\FormContainer");
+		$container = $this->control->lookup("Nette\Forms\Container");
 
 		$this->button = new SubmitButton($this->buttonText);
 		$this->button->setValidationScope(false);

--- a/JsonDependentSelectBox.php
+++ b/JsonDependentSelectBox.php
@@ -7,28 +7,29 @@
 
 namespace DependentSelectBox;
 
-use Nette\Environment;
-use Nette\Application\JsonResponse;
+use Nette\Application\Responses\JsonResponse;
+
 
 // \Nette\Forms\FormContainer::extensionMethod("addJsonDependentSelectBox", "DependentSelectBox\JsonDependentSelectBox::formAddJsonDependentSelectBox");
 
-class JsonDependentSelectBox extends DependentSelectBox {
+class JsonDependentSelectBox extends DependentSelectBox
+{
 
 	public static $jsonResoponseItems = array();
 
 	public function submitButtonHandler($button) {
 		parent::submitButtonHandler($button);
-		if(Environment::getApplication()->getPresenter()->isAjax())
+		if ($this->presenter->isAjax())
 			$this->addJsonResponseItem($this);
 	}
-	
+
 	protected function addJsonResponseItem($selectBox) {
 		self::$jsonResoponseItems[] = $selectBox;
 		if($selectBox instanceof DependentSelectBox)
 			foreach($selectBox->childs as $child)
 				$child->addJsonResponseItem($child);
 	}
-	
+
 	public static function tryJsonResponse() {
 		if(empty(self::$jsonResoponseItems))
 			return;
@@ -44,7 +45,7 @@ class JsonDependentSelectBox extends DependentSelectBox {
 			);
 		}
 		$response = new JsonResponse($payload);
-		Environment::getApplication()->getPresenter()->sendResponse($response);
+		$this->presenter->sendResponse($response);
 	}
 
 	public static function formAddJsonDependentSelectBox($_this, $name, $label, $parents, $dataCallback) {


### PR DESCRIPTION
namespaces + class names changed

note: the deprecated Environment class originally used in JsonDependentSelectBox replaced with "$form->presenter" call
