### PR TITLE
Update commented extensionMethod for Nette 2.0.3 stable.

### DIFF
--- a/JsonDependentSelectBox.php
+++ b/JsonDependentSelectBox.php
@@ -12,7 +12,7 @@ use Nette\Forms\Container as FormContainer;
 use Nette\Application\UI\Presenter;
 use Nette\InvalidStateException;
 
-// \Nette\Forms\FormContainer::extensionMethod("addJsonDependentSelectBox", "DependentSelectBox\JsonDependentSelectBox::formAddJsonDependentSelectBox");
+// \Nette\Forms\Container::extensionMethod("addJsonDependentSelectBox", "DependentSelectBox\JsonDependentSelectBox::formAddJsonDependentSelectBox");
 
 class JsonDependentSelectBox extends DependentSelectBox
 {


### PR DESCRIPTION
Nette\Forms\FormContainer has been changed to Nette\Forms\Container. 
